### PR TITLE
Unity Ads: Remove Helium reward from partner API

### DIFF
--- a/UnityAdsAdapter/src/main/java/com/chartboost/helium/unityadsadapter/UnityAdsAdapter.kt
+++ b/UnityAdsAdapter/src/main/java/com/chartboost/helium/unityadsadapter/UnityAdsAdapter.kt
@@ -376,7 +376,7 @@ class UnityAdsAdapter : PartnerAdapter {
                             state == UnityAds.UnityAdsShowCompletionState.COMPLETED
                         ) {
                             PartnerLogController.log(DID_REWARD)
-                            listener?.onPartnerAdRewarded(partnerAd, Reward(0, " "))
+                            listener?.onPartnerAdRewarded(partnerAd)
                                 ?: PartnerLogController.log(
                                     CUSTOM,
                                     "Unable to fire onPartnerAdRewarded for Unity Ads adapter. " +


### PR DESCRIPTION
Don't merge yet. Depends upon Bichen's upcoming Helium PR.