### PR TITLE
[HB-7187] Update UnityAds adapter to perform `setUp` on `IO` instead of `Main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.4.9.2.2
+- Performs initialization on `IO` to help reduce potential ANR issues.
+
 ### 4.4.9.2.1
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Unity Ads adapter mediates Unity Ads via the Chartboost
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.9.2.1"
+    implementation "com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.9.2.2"
 ```
 
 ## Contributions

--- a/UnityAdsAdapter/build.gradle.kts
+++ b/UnityAdsAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.4.9.2.1"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.4.9.2.2"
         buildConfigField("String", "CHARTBOOST_MEDIATION_UNITY_ADS_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/UnityAdsAdapter/src/main/java/com/chartboost/mediation/unityadsadapter/UnityAdsAdapter.kt
+++ b/UnityAdsAdapter/src/main/java/com/chartboost/mediation/unityadsadapter/UnityAdsAdapter.kt
@@ -26,7 +26,9 @@ import com.unity3d.services.banners.BannerErrorInfo
 import com.unity3d.services.banners.BannerView
 import com.unity3d.services.banners.UnityBannerSize
 import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -127,7 +129,7 @@ class UnityAdsAdapter : PartnerAdapter {
     override suspend fun setUp(
         context: Context,
         partnerConfiguration: PartnerConfiguration,
-    ): Result<Unit> {
+    ): Result<Unit> = withContext(IO) {
         PartnerLogController.log(SETUP_STARTED)
 
         readinessTracker.clear()
@@ -138,7 +140,7 @@ class UnityAdsAdapter : PartnerAdapter {
             ?.let { gameId ->
                 setMediationMetadata(context)
 
-                return suspendCancellableCoroutine { continuation ->
+                return@withContext suspendCancellableCoroutine { continuation ->
                     fun resumeOnce(result: Result<Unit>) {
                         if (continuation.isActive) {
                             continuation.resume(result)
@@ -179,7 +181,7 @@ class UnityAdsAdapter : PartnerAdapter {
                 }
             } ?: run {
             PartnerLogController.log(SETUP_FAILED, "Missing game_id value.")
-            return Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_INITIALIZATION_FAILURE_INVALID_CREDENTIALS))
+            return@withContext Result.failure(ChartboostMediationAdException(ChartboostMediationError.CM_INITIALIZATION_FAILURE_INVALID_CREDENTIALS))
         }
     }
 


### PR DESCRIPTION
To reduce the potential of ANRs, the adapter `setUp` method has been changed to be perform the work on the `IO` coroutine context.