### PR TITLE
[HB-7240] UnityAds SDK `4.9.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.4.9.3.0
+- This version of the adapter has been certified with Unity Ads SDK 4.9.3.
+
 ### 4.4.9.2.1
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Unity Ads adapter mediates Unity Ads via the Chartboost
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.9.2.1"
+    implementation "com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.9.3.0"
 ```
 
 ## Contributions

--- a/UnityAdsAdapter/build.gradle.kts
+++ b/UnityAdsAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.4.9.2.1"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.4.9.3.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_UNITY_ADS_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -70,7 +70,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     // Partner SDK
-    implementation("com.unity3d.ads:unity-ads:4.9.2")
+    implementation("com.unity3d.ads:unity-ads:4.9.3")
 
     // Adapter Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")


### PR DESCRIPTION
Updates the adapter to use UnityAds SDK version `4.9.3`.